### PR TITLE
 Support Docker 

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+MYSQL_DATABASE_NAME=faka
+MYSQL_ROOT_PASSWORD=zsnmwyzsnmwyzsnmwy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,19 @@
+before_script:
+  - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
+  - git clone http://192.168.1.212:10030/jj/zfaka.git $(pwd)/site
+
+build-nginx:
+  stage: build
+  script:
+    - docker build  -f Dockerfile.nginx -t "$DOCKER_USER:nginx" .
+    - docker push "$DOCKER_USER:nginx"
+  tags:
+    - docker-build
+
+build-php:
+  stage: build
+  script:
+    - docker build  -f Dockerfile.php -t "$DOCKER_USER:php" .
+    - docker push "$DOCKER_USER:php"
+  tags:
+    - docker-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,12 @@
 before_script:
   - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
   - git clone http://192.168.1.212:10030/jj/zfaka.git $(pwd)/site
+  - mv $(pwd)/site/conf/application.ini.new $(pwd)/site/conf/application.ini
 
 build-nginx:
   stage: build
   script:
-    - docker build  -f Dockerfile.nginx -t "$DOCKER_USER:nginx" .
+    - docker build  -f Dockerfile.nginx -t "$DOCKER_USER/zfaka:nginx" .
     - docker push "$DOCKER_USER:nginx"
   tags:
     - docker-build
@@ -13,7 +14,7 @@ build-nginx:
 build-php:
   stage: build
   script:
-    - docker build  -f Dockerfile.php -t "$DOCKER_USER:php" .
+    - docker build  -f Dockerfile.php -t "$DOCKER_USER/zfaka:php" .
     - docker push "$DOCKER_USER:php"
   tags:
     - docker-build

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,0 +1,14 @@
+FROM nginx:1.11
+
+MAINTAINER zsnmwy <szlszl35622@gmail.com>
+
+ENV TZ=Asia/Shanghai
+
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+
+COPY ./site /usr/share/nginx/html
+
+RUN chmod a+w /usr/share/nginx/html/conf/application.ini && \
+    chmod -R a+w+r /usr/share/nginx/html/install/ && \
+    chmod -R a+w+r /usr/share/nginx/html/temp && \
+    chmod -R a+w /usr/share/nginx/html/log

--- a/Dockerfile.php
+++ b/Dockerfile.php
@@ -1,0 +1,66 @@
+FROM php:7.0-fpm-jessie
+
+MAINTAINER zsnmwy <szlszl35622@gmail.com>
+
+ENV TZ=Asia/Shanghai
+
+COPY sources.list /etc/apt/sources.list
+
+RUN set -xe \
+    && echo "构建依赖" \
+    && buildDeps=" \
+        build-essential \
+        dh-php5 \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libmcrypt-dev \
+        libpng12-dev \
+        wget \
+    " \
+    && echo "运行依赖" \
+    && runtimeDeps=" \
+        libfreetype6 \
+        libjpeg62-turbo \
+        libmcrypt4 \
+        libpng12-0 \
+    " \
+    && echo "安装 php 以及编译构建组件所需包" \
+    && DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get install -y ${runtimeDeps} ${buildDeps} --no-install-recommends \
+    && echo "编译安装 php 组件" \
+    && docker-php-ext-install iconv mcrypt mysqli pdo pdo_mysql zip \
+    && docker-php-ext-configure gd \
+        --with-freetype-dir=/usr/include/ \
+        --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install gd \
+    && echo "编译安装 yaf" \
+    && wget -c http://pecl.php.net/get/yaf-3.0.2.tgz \
+    && tar zxf yaf-3.0.2.tgz \
+    && cd yaf-3.0.2/ \
+    && phpize \
+    && ./configure --with-php-config=/usr/local/bin/php-config \
+    && make \
+    && make install \
+    && make clean \
+    && DEBIAN_FRONTEND=noninteractive apt-get install cron -y \
+    && echo "清理" \
+    && apt-get purge -y --auto-remove \
+        -o APT::AutoRemove::RecommendsImportant=false \
+        -o APT::AutoRemove::SuggestsImportant=false \
+        $buildDeps \
+    && rm -rf /var/cache/apt/* \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY ./php.ini /usr/local/etc/php/
+
+COPY ./php.conf /usr/local/etc/php/conf.d/php.conf
+
+COPY ./site /usr/share/nginx/html
+
+RUN chmod a+w /usr/share/nginx/html/conf/application.ini && \
+    chmod -R a+w+r /usr/share/nginx/html/install/ && \
+    chmod -R a+w+r /usr/share/nginx/html/temp && \
+    chmod -R a+w /usr/share/nginx/html/log
+
+RUN (crontab -l 2>/dev/null; echo '*/2 * * * * php -q /usr/share/nginx/html/public/cli.php request_uri="/crontab/sendemail/index"') | crontab -

--- a/Dockerfile.php
+++ b/Dockerfile.php
@@ -43,6 +43,8 @@ RUN set -xe \
     && make \
     && make install \
     && make clean \
+    && rm -rf ../yaf-3.0.2 \
+    && rm -rf ../yaf-3.0.2.tgz \
     && DEBIAN_FRONTEND=noninteractive apt-get install cron -y \
     && echo "清理" \
     && apt-get purge -y --auto-remove \

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
 
 # 二、系统部署
 
+## [使用docker-compose快速部署(网速快，只需要几分钟)](https://github.com/zsnmwy/zfaka/wiki/%E4%BD%BF%E7%94%A8docker-compose%E5%BF%AB%E9%80%9F%E9%83%A8%E7%BD%B2(%E7%BD%91%E9%80%9F%E5%BF%AB%EF%BC%8C%E5%8F%AA%E9%9C%80%E8%A6%81%E5%87%A0%E5%88%86%E9%92%9F)
+
 ## 2.1 环境安装
 
 ### 2.1.1 lnmp环境

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 # 二、系统部署
 
-## [使用docker-compose快速部署(网速快，只需要几分钟)](https://github.com/zsnmwy/zfaka/wiki/%E4%BD%BF%E7%94%A8docker-compose%E5%BF%AB%E9%80%9F%E9%83%A8%E7%BD%B2(%E7%BD%91%E9%80%9F%E5%BF%AB%EF%BC%8C%E5%8F%AA%E9%9C%80%E8%A6%81%E5%87%A0%E5%88%86%E9%92%9F)
+## [使用docker-compose快速部署(网速快，只需要几分钟)](https://github.com/zsnmwy/zfaka/wiki/%E4%BD%BF%E7%94%A8docker-compose%E5%BF%AB%E9%80%9F%E9%83%A8%E7%BD%B2)
 
 ## 2.1 环境安装
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '2'
 services:
     nginx:
         image: "zsnmwy/zfaka:nginx"
+        restart: always
+        container_name: nginx-zfaka
         ports:
             - "80:80"
         networks:
@@ -11,12 +13,16 @@ services:
             - mysql
     php:
         image: "zsnmwy/zfaka:php"
+        restart: always
+        container_name: php-zfaka
         networks:
             - frontend
             - backend
 
     mysql:
         image: "mysql:5.5"
+        restart: always
+        container_name: mysql-zfaka
         environment:
           TZ: 'Asia/Shanghai'
           MYSQL_DATABASE: ${MYSQL_DATABASE_NAME}
@@ -28,7 +34,7 @@ services:
 
     phpmyadmin:
       image: phpmyadmin/phpmyadmin
-      container_name: phpmyadmin
+      container_name: phpmyadmin-zfaka
       environment:
         - PMA_ARBITRARY=1
       restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '2'
+services:
+    nginx:
+        image: "zsnmwy/zfaka:nginx"
+        ports:
+            - "80:80"
+        networks:
+            - frontend
+        depends_on:
+            - php
+            - mysql
+    php:
+        image: "zsnmwy/zfaka:php"
+        networks:
+            - frontend
+            - backend
+
+    mysql:
+        image: "mysql:5.5"
+        environment:
+          TZ: 'Asia/Shanghai'
+          MYSQL_DATABASE: ${MYSQL_DATABASE_NAME}
+          MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+        volumes:
+          - /opt/zfaka/mysql:/var/lib/mysql
+        networks:
+            - backend
+
+    phpmyadmin:
+      image: phpmyadmin/phpmyadmin
+      container_name: phpmyadmin
+      environment:
+        - PMA_ARBITRARY=1
+      restart: always
+      ports:
+        - 8080:80
+      volumes:
+        - /sessions
+      networks:
+        - backend
+networks:
+    frontend:
+    backend:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,49 @@
+server {
+    listen 80;
+
+    server_name _;
+
+    charset utf-8;
+
+    root   /usr/share/nginx/html/public;
+    index  index.php index.html index.htm;
+
+    gzip on;
+    gzip_disable "msie6";
+    gzip_types text/plain text/css text/xml text/javascript application/json
+        application/x-javascript application/xml application/xml+rss application/javascript;
+
+    error_page 404 = /index.php;
+
+    access_log off;
+    error_log /var/log/nginx/error.log crit;
+
+    client_max_body_size 64m;
+
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+        
+        if (!-e $request_filename) {
+                rewrite ^/(.*)$ /index.php?$1 last;
+        }
+    }
+
+    location /. {
+        return 404;
+    }
+
+    location ~ \.php$ {
+         include fastcgi_params;
+         try_files $uri =404;
+
+         fastcgi_pass php:9000;
+         fastcgi_split_path_info ^(.+\.php)(/.+)$;
+         fastcgi_read_timeout 300;
+         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+         fastcgi_index index.php;
+    }
+
+    location ~ /\.ht {
+        deny  all;
+    }
+}

--- a/php.conf
+++ b/php.conf
@@ -1,0 +1,2 @@
+[Date]
+date.timezone = Asia/Shanghai

--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,3 @@
+extension=yaf.so
+yaf.environ='product'
+yaf.use_namespace=1

--- a/sources.list
+++ b/sources.list
@@ -1,0 +1,3 @@
+deb http://mirrors.163.com/debian/ jessie main
+deb http://mirrors.163.com/debian/ jessie-updates main
+deb http://mirrors.163.com/debian-security/ jessie/updates main


### PR DESCRIPTION
增加docker支持，实现快速部署。

用法写在了[wiki](https://github.com/zsnmwy/zfaka/wiki/%E4%BD%BF%E7%94%A8docker-compose%E5%BF%AB%E9%80%9F%E9%83%A8%E7%BD%B2)。

---

麻烦测试下以下几点，再考虑是否合并。

---

**邮件发送问题**

- 可能是我的SMTP的配置问题

- 可能是crontab没生效

![image](https://user-images.githubusercontent.com/35299017/44954079-27dc9c00-aed0-11e8-8d32-a2d73a7603ee.png)

一直处于未发送状态

crontab的配置，我是配置在[PHP镜像里面](https://github.com/zsnmwy/zfaka/blob/8bea469436dddd6bd3363c8fb890b5705fa9cdf4/Dockerfile.php#L68)。

`RUN (crontab -l 2>/dev/null; echo '*/2 * * * * php -q /usr/share/nginx/html/public/cli.php request_uri="/crontab/sendemail/index"') | crontab -`

---

Nginx的path_info问题

因为对Nginx不是太熟悉，所以在readme里面提到的，`务必：注意nginx环境下path_info的配置(记的要取消)`。

是不是指代[这个](https://github.com/zsnmwy/zfaka/blob/8bea469436dddd6bd3363c8fb890b5705fa9cdf4/nginx.conf#L40)？

```
    location ~ \.php$ {
         include fastcgi_params;
         try_files $uri =404;

         fastcgi_pass php:9000;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_read_timeout 300;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_index index.php;
}
```

我在调试的时候，好像并没有发现啥问题，但是没有测试过支付的模块。
因为我没有相关的收钱的KEY，也没有弄。

也麻烦看看 `nginx.conf`,有没有什么问题。